### PR TITLE
feat: framework config in when beidou build

### DIFF
--- a/packages/beidou-cli/lib/commands/build.js
+++ b/packages/beidou-cli/lib/commands/build.js
@@ -5,11 +5,12 @@ const path = require('path');
 const debug = require('debug')('beidou-cli');
 const { Command } = require('egg-bin');
 const { log } = require('../helper');
-const { framework, cmdName } = require('../helper');
+const { getArgvWithDefaultFramework, framework, cmdName } = require('../helper');
 
 module.exports = class BuildCMD extends Command {
   constructor(rawArgv) {
-    super(rawArgv);
+    const argv = getArgvWithDefaultFramework(rawArgv);
+    super(argv);
     this.usage = `Usage: ${cmdName} build [options]`;
     this.options = {
       target: {

--- a/packages/beidou-cli/lib/commands/build.js
+++ b/packages/beidou-cli/lib/commands/build.js
@@ -5,7 +5,8 @@ const path = require('path');
 const debug = require('debug')('beidou-cli');
 const { Command } = require('egg-bin');
 const { log } = require('../helper');
-const { getArgvWithDefaultFramework, framework, cmdName } = require('../helper');
+const { getArgvWithDefaultFramework = 'beidou-core',
+  framework, cmdName } = require('../helper');
 
 module.exports = class BuildCMD extends Command {
   constructor(rawArgv) {

--- a/packages/beidou-cli/lib/helper/index.js
+++ b/packages/beidou-cli/lib/helper/index.js
@@ -26,3 +26,17 @@ exports.getArgvWithDefaultConfig = (argv) => {
   }
   return argv;
 };
+
+exports.getArgvWithDefaultFramework = (argv) => {
+  let findFramework = false;
+  for (const arg of argv) {
+    if (arg.includes('--framework')) {
+      findFramework = true;
+    }
+  }
+  if (!findFramework) {
+    argv.push(`--framework=${configs.framework}`);
+  }
+
+  return argv;
+};

--- a/packages/beidou-webpack/bin/build.js
+++ b/packages/beidou-webpack/bin/build.js
@@ -6,9 +6,12 @@ const process = require('process');
 const { argv } = require('argh');
 const fs = require('fs');
 const path = require('path');
-const { Application } = require('beidou-core');
-const Loader = require('beidou-core').AppWorkerLoader;
 const builder = require('../lib/builder');
+
+const { target, framework, dev } = argv;
+
+const { Application } = require(framework);
+const Loader = require(framework).AppWorkerLoader;
 
 // set serverEnv=local to ensure webpack plugin enable
 process.env.EGG_SERVER_ENV = 'local';
@@ -21,9 +24,7 @@ const app = new Application({
 });
 
 // build in production environment as default
-app.config.env = argv.dev ? 'local' : 'prod';
-
-const { target } = argv;
+app.config.env = dev ? 'local' : 'prod';
 
 if (target && !['node', 'browser'].includes(target)) {
   app.coreLogger.error(


### PR DESCRIPTION
## Checklist

* [x] `npm test` passes
* [x] tests are included
* [x] documentation is changed or added
* [x] commit message follows commit guidelines

## Affected plugin(s)

- beidou-cli
- beidou-webpack

## Description of change

Add default `--framework` argument when run `beidou build`.

> This feature will not affect current build behavior. Only take effects when using framework extend from `beidou-core`, such as internal version of beidou in Alibaba Group.
