### PR TITLE
fix(isomorphic): suppress warning from react, by adding requestAnimationFrame polyfill

### DIFF
--- a/packages/beidou-isomorphic/lib/polyfill.js
+++ b/packages/beidou-isomorphic/lib/polyfill.js
@@ -23,6 +23,7 @@ function setPolyfill(window) {
     removeListener() {},
   });
   window.matchMedia = global.matchMedia;
+  global.requestAnimationFrame = /* istanbul ignore next */ () => {};
 }
 
 exports.basicPolyfill = () => {


### PR DESCRIPTION
## Description of change

react组件在服务器端render时，react会报warning "React depends on requestAnimationFrame. Make sure that you load a polyfill in older browsers"

修复方式是加requestAnimationFrame polyfill
