### PR TITLE
fix: icon render issue in example(#120)

### DIFF
--- a/examples/antd-components/client/layout.jsx
+++ b/examples/antd-components/client/layout.jsx
@@ -8,7 +8,7 @@ export const View = (props) => {
         <title>AntD Components</title>
         <link
           rel="stylesheet"
-          href="https://unpkg.com/antd@3.2.3/dist/antd.min.css"
+          href="https://unpkg.com/antd@3.10.9/dist/antd.min.css"
         />
         <link rel="stylesheet" href={helper.asset('index.css')} />
       </head>

--- a/examples/antd-components/package.json
+++ b/examples/antd-components/package.json
@@ -12,7 +12,7 @@
     "build:node": "beidou build --target=node"
   },
   "dependencies": {
-    "antd": "^3.2.3",
+    "antd": "^3.10.9",
     "babel-eslint": "^8.1.2",
     "babel-polyfill": "^6.26.0",
     "beidou-cli": "^1.0.10",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly docs.
Contributors guide: https://github.com/alibaba/beidou/blob/master/.github/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上文档。
Contributors guide: https://github.com/alibaba/beidou/blob/master/.github/CONTRIBUTING.zh-CN.md
-->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

* [ ] `npm test` passes
* [ ] tests are included
* [ ] documentation is changed or added
* [ ] commit message follows commit guidelines

## Affected plugin(s)

<!-- Provide affected core subsystem(s). -->

## Description of change

使用example中的antd-components时，发现icon会重复渲染：

<img width="648" alt="wx20181127-100110 2x" src="https://user-images.githubusercontent.com/16172317/49054774-51d3ff00-f230-11e8-9e7f-f8c566b16fd4.png">

经过查看antd的源码时发现，icon的style其实已经做出修复：

// ant-design/components/style/mixins/iconfont.less
<img width="470" alt="wx20181127-100505 2x" src="https://user-images.githubusercontent.com/16172317/49054819-82b43400-f230-11e8-8474-26cfc123fa54.png">

对比存在此问题的antd版本和最新版本antd打包后的css文件：

// 3.2.3
<img width="272" alt="wx20181127-100549 2x" src="https://user-images.githubusercontent.com/16172317/49054975-02da9980-f231-11e8-93be-61f3ce28c82e.png">

// 3.9.10
<img width="254" alt="wx20181127-100615 2x" src="https://user-images.githubusercontent.com/16172317/49054978-04a45d00-f231-11e8-9306-6126df842cb4.png">

发现的存在版本差异，将antd-component例子里的antd替换成新版本，运行后的效果：

<img width="1438" alt="wx20181127-101007 2x" src="https://user-images.githubusercontent.com/16172317/49055047-2ef61a80-f231-11e8-9ba8-49c8bc25ba7e.png">

其他页面也都正常，可确认问题解决。

<!-- Provide a description of the change below this comment. -->
