### PR TITLE
fix: add build folder when static server

### DIFF
--- a/packages/beidou-core/config/config.default.js
+++ b/packages/beidou-core/config/config.default.js
@@ -54,4 +54,19 @@ module.exports = appInfo => ({
     'bodyParser',
     'overrideMethod',
   ],
+
+  /**
+   * enable app/build and app/public folder for static-server
+   * @member {Array} Config#static
+   */
+  static: {
+    prefix: '/public',
+    dir: [
+      path.join(appInfo.baseDir, '/app/public'),
+      {
+        prefix: '/build',
+        dir: path.join(appInfo.baseDir, '/build'),
+      },
+    ],
+  },
 });

--- a/packages/beidou-core/config/config.default.js
+++ b/packages/beidou-core/config/config.default.js
@@ -60,9 +60,11 @@ module.exports = appInfo => ({
    * @member {Array} Config#static
    */
   static: {
-    prefix: '/public',
     dir: [
-      path.join(appInfo.baseDir, '/app/public'),
+      {
+        prefix: '/public',
+        dir: path.join(appInfo.baseDir, '/app/public'),
+      },
       {
         prefix: '/build',
         dir: path.join(appInfo.baseDir, '/build'),

--- a/packages/beidou-core/package.json
+++ b/packages/beidou-core/package.json
@@ -30,7 +30,7 @@
     "beidou-view-react": "^2.0.1",
     "beidou-webpack": "^2.0.1",
     "depd": "^1.1.2",
-    "egg": "^2.3.0"
+    "egg": "^2.18.0"
   },
   "peerDependencies": {
     "react": "^16.2.0",

--- a/packages/beidou-core/test/fixtures/apps/static-server-with-build-dir/app/public/bar.js
+++ b/packages/beidou-core/test/fixtures/apps/static-server-with-build-dir/app/public/bar.js
@@ -1,0 +1,1 @@
+console.log('foo');

--- a/packages/beidou-core/test/fixtures/apps/static-server-with-build-dir/build/foo.js
+++ b/packages/beidou-core/test/fixtures/apps/static-server-with-build-dir/build/foo.js
@@ -1,0 +1,1 @@
+console.log('bar');

--- a/packages/beidou-core/test/fixtures/apps/static-server-with-build-dir/package.json
+++ b/packages/beidou-core/test/fixtures/apps/static-server-with-build-dir/package.json
@@ -1,0 +1,3 @@
+{
+    "name": "static-server-build-dir"
+}

--- a/packages/beidou-core/test/lib/beidou.test.js
+++ b/packages/beidou-core/test/lib/beidou.test.js
@@ -41,4 +41,26 @@ describe('test/lib/beidou.test.js', () => {
       app.expect('stdout', /Beidou started/).ready(done);
     });
   });
+
+  describe('Static server started success', () => {
+    let app;
+
+    before((done) => {
+      app = utils.startMaster('apps/static-server-with-build-dir', {
+        coverage: true,
+      });
+      app.ready(done);
+    });
+
+    afterEach(() => {
+      app.close();
+    });
+
+    it('should get 200 when request a static file under "build" folder', () => {
+      return app.httpRequest()
+        .get('/build/foo.js')
+        .expect(/console.log\(\'bar\'\);/)
+        .expect(200);
+    });
+  });
 });

--- a/packages/beidou-core/test/lib/beidou.test.js
+++ b/packages/beidou-core/test/lib/beidou.test.js
@@ -52,7 +52,7 @@ describe('test/lib/beidou.test.js', () => {
       app.ready(done);
     });
 
-    afterEach(() => {
+    after(() => {
       app.close();
     });
 
@@ -60,6 +60,13 @@ describe('test/lib/beidou.test.js', () => {
       return app.httpRequest()
         .get('/build/foo.js')
         .expect(/console.log\(\'bar\'\);/)
+        .expect(200);
+    });
+
+    it('should get 200 when request a static file under "app/public" folder', () => {
+      return app.httpRequest()
+        .get('/public/bar.js')
+        .expect(/console.log\(\'foo\'\);/)
         .expect(200);
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly docs.
Contributors guide: https://github.com/alibaba/beidou/blob/master/.github/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上文档。
Contributors guide: https://github.com/alibaba/beidou/blob/master/.github/CONTRIBUTING.zh-CN.md
-->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

* [x] `npm test` passes
* [x] tests are included
* [ ] documentation is changed or added
* [x] commit message follows commit guidelines

## Affected plugin(s)
`beidou-core`
<!-- Provide affected core subsystem(s). -->
`package.json`、`config.default.js`
## Description of change
增加了egg-static多个静态静态目录的配置，默认开启`/public/`，`/build/`的静态资源访问，映射文件夹为项目根目录下`/app/public`、`/build`
⚠️：本次更新需要更新`package.json`中的依赖，原因：`egg-static`在v2.2之后支持多目录静态资源配置，同时`egg`在2.18.0后，加入了`egg-static v2.2.0` 
<!-- Provide a description of the change below this comment. -->
