### PR TITLE
fix: not prevent 30x requst to webpack server

### DIFF
--- a/packages/beidou-webpack/app/middleware/webpack.js
+++ b/packages/beidou-webpack/app/middleware/webpack.js
@@ -30,7 +30,7 @@ module.exports = function (options, app) {
     }
     const notFound = await new Promise((resolve) => {
       webpackRequest.on('response', function (res) {
-        if (res.statusCode >= 200 && res.statusCode < 300) {
+        if (res.statusCode >= 200 && res.statusCode < 400) {
           debug('redirect request to webpack with url: %s', webpackUrl);
           ctx.res.statusCode = res.statusCode;
           /* eslint-disable guard-for-in */


### PR DESCRIPTION

## Checklist

* [ ] `npm test` passes
* [x] tests are included
* [x] documentation is changed or added
* [x] commit message follows commit guidelines

## Affected plugin(s)

- beidou-webpack

## Description of change

statusCode between 200 and 400 will be redirected to webpack dev server.

When `disable cache` not enable in browser,  304 got actually.
