### PR TITLE
feat: support ssr for egg framework

### DIFF
--- a/packages/egg-beidou/README.md
+++ b/packages/egg-beidou/README.md
@@ -8,12 +8,12 @@ neet to open the plugin for using
 
 ### extends
 
-- ctx.render(filepath,props) Render the `filepath` by proprs and set the result as `ctx.body` value
-- ctx.renderView(filepath,props) Render the `filepath` by proprs and return result for SSR
+- ctx.ssr(filepath,props) Render the `filepath` by proprs and return result for SSR, `filepath` is absolute path
 
 ## Configure
 
 ```js
+// config/pulgin.js
 exports.beidou = {
   enable: true,
   package: 'egg-beidou',
@@ -21,8 +21,14 @@ exports.beidou = {
 
 // config.default.js
 exports.beidou = {
-  static: true, //  whether use static render for SSR
+  static: false, //  whether use static render for SSR
   stream: false, //  whether use stream render for SSR
+  cache: true, // whether open require cache
+  onError: function(error){  // call the function when render occur error
+    // do something
+  },
+  view:"/home/admin/project/",
+  extensions: [ '.js', 'jsx', '.ts', '.tsx' ] , // file suffix
 };
 ```
 
@@ -30,21 +36,57 @@ exports.beidou = {
 
 > see more example to test/exmaple folder
 
+### case1 : render packaged code
 ```js
 // Controller
 'use strict';
 
 exports.index = async function(ctx) {
-  await ctx.render('simple/index.js', {
+  await ctx.ssr('simple/index.js', {
     data: {
       text: 'hello world!',
     },
   });
 };
 
-// if you need pass server data to render
+// put your data into react render for react this.props
 exports.simple = async function(ctx) {
-  ctx.body = await ctx.renderView('simple/index.js', {
+  ctx.body = await ctx.ssr('simple/index.js', {
+    data: {
+      text: 'hello world!',
+    },
+  });
+};
+
+// if you need to pass absolute path
+exports.test = async function(ctx) {
+  ctx.body = await ctx.ssr('/usr/local/project/simple/index.js', {
+    data: {
+      text: 'hello world!',
+    },
+  });
+};
+```
+
+### case2: render react native code
+> The scheme of rendering React code by this plug-in is consistent with that of Beidou isomorphic framework, which can be used with reference to Beidou isomorphic framework document.
+
+```js
+// config/plugin.js
+// install egg-plugin:  beidou-isomorphic & beidou-webpack and enable plugin
+isomorphic: {
+  enable: true,
+  package: 'beidou-isomorphic',
+},
+webpack: {
+  enable: true,
+  package: 'beidou-webpack',
+  env: [ 'local', 'unittest' ],
+}
+
+// controller/index.js
+exports.simple = async function(ctx) {
+  ctx.body = await ctx.ssr('simple/index.jsx', {
     data: {
       text: 'hello world!',
     },

--- a/packages/egg-beidou/app.js
+++ b/packages/egg-beidou/app.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const BeidouView = require('./lib/beidou');
 const { basicPolyfill, setGlobal } = require('beidou-isomorphic/lib/polyfill');
 
-module.exports = (app) => {
+module.exports = app => {
   basicPolyfill();
   setGlobal(app.config.env);
-  app.view.use('beidou', BeidouView);
 };

--- a/packages/egg-beidou/app/extend/context.js
+++ b/packages/egg-beidou/app/extend/context.js
@@ -1,0 +1,56 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const is = require('is');
+const BeidouView = require('../../lib/beidou');
+const symbol = Symbol.for('beidou#renderView');
+module.exports = {
+  [symbol]: null,
+  async ssr(filepath, props) {
+    let beidou = null;
+    const { beidou: option } = this.app.config;
+    if (this[symbol]) {
+      beidou = null;
+    } else {
+      beidou = new BeidouView(this);
+    }
+    let pathArr = [ filepath, path.join(option.view || this.app.baseDir, filepath) ];
+    if (is.function(this.remoteAsset)) {
+      pathArr.push(await this.remoteAsset(filepath));
+    }
+
+    if (option.extensions && is.array(option.extensions)) {
+      const pathArrExt = [];
+
+      pathArr.forEach(v => {
+        option.extensions.forEach(
+          ext => {
+            pathArrExt.push(v + ext);
+          }
+        );
+      });
+      pathArr = pathArr.concat(pathArrExt);
+    }
+    const p = pathArr.find(
+      v => {
+        return fs.existsSync(v);
+      }
+    );
+    try {
+      if (!p) {
+        throw new Error(`${filepath} is not exsit, please check it`);
+      }
+      const res = await beidou.render(p, {
+        ...props,
+        ctx: this,
+      });
+      return res;
+    } catch (e) {
+      this.coreLogger.warn(`SSRError: render ${filepath} occur exception !`, e);
+      if (option.onError) {
+        return await option.onError.call(this, e);
+      }
+      throw e;
+    }
+  },
+};

--- a/packages/egg-beidou/app/view-middlewares/custom.js
+++ b/packages/egg-beidou/app/view-middlewares/custom.js
@@ -2,7 +2,7 @@
 
 const is = require('is-type-of');
 
-module.exports = async function (viewCtx, next) {
+module.exports = async function(viewCtx, next) {
   const { Component, props } = viewCtx;
 
   const render = Component.custom;

--- a/packages/egg-beidou/app/view-middlewares/render.js
+++ b/packages/egg-beidou/app/view-middlewares/render.js
@@ -3,7 +3,7 @@
 const React = require('react');
 const through = require('through');
 
-module.exports = async function (viewCtx, next) {
+module.exports = async function(viewCtx, next) {
   await next();
   const { Component, props, view, html } = viewCtx;
   const instance = React.createElement(Component, props);

--- a/packages/egg-beidou/app/view-middlewares/script.js
+++ b/packages/egg-beidou/app/view-middlewares/script.js
@@ -2,7 +2,7 @@
 
 const is = require('is-type-of');
 
-module.exports = async function (viewCtx, next) {
+module.exports = async function(viewCtx, next) {
   const { Component, props } = viewCtx;
 
   const render = Component.script;

--- a/packages/egg-beidou/app/view-middlewares/style.js
+++ b/packages/egg-beidou/app/view-middlewares/style.js
@@ -2,7 +2,7 @@
 
 const is = require('is-type-of');
 
-module.exports = async function (viewCtx, next) {
+module.exports = async function(viewCtx, next) {
   const { Component, props } = viewCtx;
   const render = Component.style;
   if (typeof render === 'function') {

--- a/packages/egg-beidou/config/config.default.js
+++ b/packages/egg-beidou/config/config.default.js
@@ -1,13 +1,9 @@
 'use strict';
-
-const path = require('path');
-
-module.exports = appInfo => ({
+module.exports = () => ({
   beidou: {
     middlewares: [
       'render',
       'custom',
-      'cache',
       'initialprops',
       'redux',
       'partial',
@@ -18,16 +14,8 @@ module.exports = appInfo => ({
     ],
     doctype: '<!DOCTYPE html>',
     cache: true,
-    static: true,
+    static: false,
     stream: false,
-  },
-  view: {
-    mapping: {
-      '.js': 'beidou',
-    },
-    root: `${path.join(appInfo.baseDir, 'app/views')},${path.join(
-      appInfo.baseDir,
-      'clients'
-    )}`,
+    extensions: [ '.js', 'jsx', '.ts', '.tsx' ],
   },
 });

--- a/packages/egg-beidou/lib/beidou.js
+++ b/packages/egg-beidou/lib/beidou.js
@@ -26,31 +26,32 @@ class BeidouView extends BaseView {
 
   async render(...args) {
     this.ctx.type = 'html';
+    if (this.options.cache === false) {
+      this.clearCache(args[0]);
+    }
     const res = await super.render(...args);
     return res;
-  }
-
-  async renderString() {
-    this.app.logger.info('reject');
-    const err = new Error();
-    err.name = 'not implemented yet!';
-    err.status = 500;
-    throw err;
   }
 
   renderElementToStream(component, props = {}) {
     if (this.options.static) {
       return ReactDOMServer.renderToStaticNodeStream(component, props);
-    } else {
-      return ReactDOMServer.renderToNodeStream(component, props);
     }
+    return ReactDOMServer.renderToNodeStream(component, props);
+
   }
 
   renderElement(component, props = {}) {
     if (this.options.static) {
       return ReactDOMServer.renderToStaticMarkup(component, props);
-    } else {
-      return ReactDOMServer.renderToString(component, props);
+    }
+    return ReactDOMServer.renderToString(component, props);
+  }
+
+  clearCache(filepath) {
+    const absolutePath = path.resolve(filepath);
+    if (require.cache[absolutePath]) {
+      delete require.cache[absolutePath];
     }
   }
 }

--- a/packages/egg-beidou/package.json
+++ b/packages/egg-beidou/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "beidou-isomorphic": "^2.0.1",
     "beidou-view": "^2.0.1",
+    "is": "^3.3.0",
     "koa-compose": "^4.1.0",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
@@ -24,11 +25,11 @@
   },
   "devDependencies": {
     "autod": "^3.0.1",
-    "egg": "^2.10.0",
-    "egg-bin": "^4.0.0",
-    "egg-mock": "^3.7.1",
     "eslint": "^5.3.0",
-    "eslint-config-egg": "^7.0.0"
+    "eslint-config-egg": "^7.0.0",
+    "egg-bin": "^4.0.0",
+    "egg": "^2.10.0",
+    "egg-mock": "^3.7.1"
   },
   "scripts": {
     "autod": "autod",

--- a/packages/egg-beidou/test/beidou.test.js
+++ b/packages/egg-beidou/test/beidou.test.js
@@ -30,10 +30,26 @@ describe('test/beidou.test.js', () => {
       .get('/spa')
       .expect(200));
 
+    it('ssr should status 200', () => app.httpRequest(app.callback())
+      .get('/ssr')
+      .expect(200));
+
     it('filepath not`t exsit, should status 500', () => app.httpRequest(app.callback())
       .get('/miss')
       .expect(500));
   });
+
+
+  describe('render file and default add suffix  ', () => {
+    it('simple should status 200 for file suffix', () => app.httpRequest(app.callback())
+      .get('/suffix')
+      .expect(200));
+    it('simple should status 200 for full filepath suffix', () => app.httpRequest(app.callback())
+      .get('/suffixpath')
+      .expect(200));
+
+  });
+
 });
 
 describe('test/beidou.test.js', () => {

--- a/packages/egg-beidou/test/example/package.json
+++ b/packages/egg-beidou/test/example/package.json
@@ -1,0 +1,16 @@
+{
+  "dependencies": {
+    "babel-loader": "^8.0.5",
+    "babel-polyfill": "^6.26.0",
+    "css-loader": "^2.1.1",
+    "history": "^4.9.0",
+    "null-loader": "^0.1.1",
+    "redux": "^4.0.1",
+    "redux-actions": "^2.6.5",
+    "redux-saga": "^1.0.2",
+    "sass-loader": "^7.1.0",
+    "style-loader": "^0.23.1",
+    "webpack": "^4.29.6",
+    "webpack-cli": "^3.3.0"
+  }
+}

--- a/packages/egg-beidou/test/example/redux/page.jsx
+++ b/packages/egg-beidou/test/example/redux/page.jsx
@@ -1,5 +1,6 @@
+/* eslint-disable valid-jsdoc */
 import React from 'react';
-import ReactDOM from 'react-dom';
+// import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import App from './container';
 import configureStore from './store';

--- a/packages/egg-beidou/test/example/redux/store/index.js
+++ b/packages/egg-beidou/test/example/redux/store/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import { createStore, applyMiddleware, compose } from 'redux';
 import { sagaMiddleware } from '../saga';
 import rootReducer from '../reducers';

--- a/packages/egg-beidou/test/example/simple/index.jsx
+++ b/packages/egg-beidou/test/example/simple/index.jsx
@@ -23,8 +23,8 @@ export default class View extends React.Component {
     );
   }
 
-  static script(props){
-    return "<sript>window.name = hhhh</sript>"
+  // eslint-disable-next-line no-unused-vars
+  static script(props) {
+    return '<sript>window.name = hhhh</sript>';
   }
-  
 }

--- a/packages/egg-beidou/test/example/webpack.config.js
+++ b/packages/egg-beidou/test/example/webpack.config.js
@@ -1,11 +1,11 @@
-'use strict';
 const path = require('path');
 const webpack = require('webpack');
+
 module.exports = Object.assign({}, {
   entry: {
-    "redux/page": path.join(__dirname, './redux/page.jsx'),
-    "spa/index": path.join(__dirname, './spa/index.jsx'),
-    "simple/index": path.join(__dirname, './simple/index.jsx'),
+    'redux/page': path.join(__dirname, './redux/page.jsx'),
+    'spa/index': path.join(__dirname, './spa/index.jsx'),
+    'simple/index': path.join(__dirname, './simple/index.jsx'),
   },
   output: {
     path: path.join(__dirname, '../build'),
@@ -37,11 +37,13 @@ module.exports = Object.assign({}, {
       },
       {
         test: /\.css$/,
-        use: [ 'style-loader', 'css-loader' ],
+        use: [ 'null-loader', 'style-loader', 'css-loader' ],
       },
       {
         test: /\.less$/,
         use: [{
+          loader: 'null-loader',
+        }, {
           loader: 'style-loader', // creates style nodes from JS strings
         }, {
           loader: 'css-loader', // translates CSS into CommonJS
@@ -52,6 +54,7 @@ module.exports = Object.assign({}, {
       {
         test: /\.scss$/,
         use: [
+          'null-loader',
           'style-loader', // creates style nodes from JS strings
           'css-loader', // translates CSS into CommonJS
           'sass-loader', // compiles Sass to CSS, using Node Sass by default

--- a/packages/egg-beidou/test/fixtures/apps/stream/app/controller/home.js
+++ b/packages/egg-beidou/test/fixtures/apps/stream/app/controller/home.js
@@ -1,9 +1,7 @@
-'use strict';
-
-exports.index = async function (ctx) {
-  ctx.body = await ctx.renderView('simple/index.js');
+exports.index = async function(ctx) {
+  ctx.body = await ctx.ssr('simple/index.js');
 };
 
-exports.miss = async function (ctx) {
-  ctx.body = await ctx.renderString('simple/index.js');
+exports.miss = async function(ctx) {
+  ctx.body = await ctx.ssr('miss/index.js');
 };

--- a/packages/egg-beidou/test/fixtures/apps/stream/app/router.js
+++ b/packages/egg-beidou/test/fixtures/apps/stream/app/router.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = (app) => {
+module.exports = app => {
   app.get('home', '/', 'home.index');
   app.get('miss', '/miss', 'home.miss');
 };

--- a/packages/egg-beidou/test/fixtures/apps/stream/config/config.default.js
+++ b/packages/egg-beidou/test/fixtures/apps/stream/config/config.default.js
@@ -3,9 +3,7 @@ const path = require('path');
 exports.beidou = {
   stream: true,
   extPaths: [],
+  view: path.join(__dirname, '../../../../build'),
 };
-exports.view = {
-  defaultViewEngine: 'beidou',
-  root: path.join(__dirname, '../../../../build'),
-};
+
 exports.keys = '0jN4Fw7ZBjo4xtrLklDg4g==';

--- a/packages/egg-beidou/test/fixtures/apps/stream/config/plugin.js
+++ b/packages/egg-beidou/test/fixtures/apps/stream/config/plugin.js
@@ -1,5 +1,3 @@
-'use strict';
-
 module.exports = {
   /**
    * Isomorphic plugin

--- a/packages/egg-beidou/test/fixtures/apps/test/app/controller/home.js
+++ b/packages/egg-beidou/test/fixtures/apps/test/app/controller/home.js
@@ -1,12 +1,30 @@
-'use strict';
-
-exports.index = async function (ctx) {
+const path = require('path');
+exports.index = async function(ctx) {
   ctx.app.config.beidou.stream = true;
   ctx.app.config.beidou.static = false;
-  ctx.body = await ctx.renderView('simple/index.js');
+  ctx.body = await ctx.ssr('/simple/index.js');
 };
 
-exports.miss = async function (ctx) {
+exports.miss = async function(ctx) {
   ctx.app.config.beidou.stream = true;
-  ctx.body = await ctx.renderView('miss/index.js');
+  ctx.body = await ctx.ssr('miss/index.js');
 };
+
+exports.ssr = async function(ctx) {
+  ctx.app.config.beidou.stream = true;
+  ctx.app.config.beidou.static = false;
+  ctx.body = await ctx.ssr(path.join(ctx.app.baseDir, '../../../', '/build/simple/index.js'));
+};
+
+exports.suffix = async function(ctx) {
+  ctx.app.config.beidou.stream = true;
+  ctx.app.config.beidou.static = false;
+  ctx.body = await ctx.ssr('/simple/index');
+};
+
+exports.suffixpath = async function(ctx) {
+  ctx.app.config.beidou.stream = true;
+  ctx.app.config.beidou.static = false;
+  ctx.body = await ctx.ssr(path.join(ctx.app.baseDir, '../../../', '/build/simple/index.js'));
+};
+

--- a/packages/egg-beidou/test/fixtures/apps/test/app/controller/redux.js
+++ b/packages/egg-beidou/test/fixtures/apps/test/app/controller/redux.js
@@ -1,10 +1,8 @@
-'use strict';
-
-exports.index = async function (ctx) {
-  ctx.body = await ctx.renderView('redux/index.js', { ctx });
+exports.index = async function(ctx) {
+  ctx.body = await ctx.ssr('redux/index.js', { ctx });
 };
 
-exports.page = async function (ctx) {
+exports.page = async function(ctx) {
   ctx.app.config.beidou.stream = false;
-  ctx.body = await ctx.renderView('redux/page.js', { ctx });
+  ctx.body = await ctx.ssr('redux/page.js', { ctx });
 };

--- a/packages/egg-beidou/test/fixtures/apps/test/app/controller/spa.js
+++ b/packages/egg-beidou/test/fixtures/apps/test/app/controller/spa.js
@@ -1,6 +1,4 @@
-'use strict';
-
-exports.index = async function (ctx) {
+exports.index = async function(ctx) {
   ctx.app.config.beidou.static = true;
-  ctx.body = await ctx.renderView('spa/index.js', { ctx });
+  ctx.body = await ctx.ssr('spa/index.js', { ctx });
 };

--- a/packages/egg-beidou/test/fixtures/apps/test/app/router.js
+++ b/packages/egg-beidou/test/fixtures/apps/test/app/router.js
@@ -1,9 +1,10 @@
-'use strict';
-
-module.exports = (app) => {
+module.exports = app => {
   app.get('home', '/', 'home.index');
   app.get('redux', '/redux', 'redux.index');
   app.get('redux/page', '/redux/page', 'redux.page');
   app.get('spa', '/spa', 'spa.index');
   app.get('miss', '/miss', 'home.miss');
+  app.get('ssr', '/ssr', 'home.ssr');
+  app.get('suffix', '/suffix', 'home.suffix');
+  app.get('suffixpath', '/suffixpath', 'home.suffixpath');
 };

--- a/packages/egg-beidou/test/fixtures/apps/test/config/config.default.js
+++ b/packages/egg-beidou/test/fixtures/apps/test/config/config.default.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
 exports.keys = '0jN4Fw7ZBjo4xtrLklDg4g==';
-exports.view = {
-  root: path.join(__dirname, '../../../../build'),
+exports.beidou = {
+  view: path.join(__dirname, '../../../../build'),
 };

--- a/packages/egg-beidou/test/fixtures/apps/test/config/plugin.js
+++ b/packages/egg-beidou/test/fixtures/apps/test/config/plugin.js
@@ -1,5 +1,3 @@
-'use strict';
-
 module.exports = {
   /**
    * Isomorphic plugin


### PR DESCRIPTION
增加北斗同构插件，用以支持Egg框架下的轻量级同构功能

## Checklist


* [x] `npm test` passes
* [x] tests are included
* [x] documentation is changed or added
* [x] commit message follows commit guidelines

## Description of change

 * 开启 egg-beidou 插件，可使用 ctx.ssr(path,props) 进行同构页面渲染
 * path路径支持 全路径、绝对路径，可配置默认文件扩展名
 * 支持require.cache缓存是否使用配置
 * 支持 render stream
 * 支持渲染错误异常处理
