### PR TITLE
feat: support custom config for preset-env

### DIFF
--- a/packages/babel-preset-beidou-client/README.md
+++ b/packages/babel-preset-beidou-client/README.md
@@ -3,7 +3,7 @@
 This preset includes the following plugins:
 
 - @babel/preset-env
-- @babel/reset-react
+- @babel/preset-react
 - @babel/preset-typescript [optional]
 - @babel/plugin-proposal-function-sent
 - @babel/plugin-proposal-decorators

--- a/packages/babel-preset-beidou-client/README.md
+++ b/packages/babel-preset-beidou-client/README.md
@@ -2,11 +2,17 @@
 
 This preset includes the following plugins:
 
-- babel-preset-env
-- babel-preset-react
-- babel-preset-stage-2
-- babel-plugin-typecheck
-- react-hot-loader
+- @babel/preset-env
+- @babel/reset-react
+- @babel/preset-typescript [optional]
+- @babel/plugin-proposal-function-sent
+- @babel/plugin-proposal-decorators
+- @babel/plugin-proposal-class-properties
+- @babel/plugin-proposal-export-namespace-from
+- @babel/plugin-proposal-numeric-separator
+- @babel/plugin-proposal-throw-expressions
+- babel-plugin-add-module-exports
+- react-hot-loader/babel [only for dev]
 
 ## Install
 
@@ -27,3 +33,16 @@ This preset support dynamic compile browser targets, set [browserslist](https://
 ```
 
 Or using default browserslist `['>1%', 'last 4 versions', 'not ie < 9']`.
+
+### Config in `.babelrc`
+
+```json
+{
+  "presets": [["babel-preset-beidou-client", { "typescript": true }]]
+}
+```
+
+**Options**
+
+- typescript: enable typescript
+- env: config passed to preset-env

--- a/packages/babel-preset-beidou-client/index.js
+++ b/packages/babel-preset-beidou-client/index.js
@@ -20,16 +20,21 @@ try {
 
 module.exports = function (api, opt) {
   api.assertVersion(7);
-
+  opt = opt || {};
+  const envOption = opt.env || {};
   const presets = [
     [
       env,
-      {
-        useBuiltIns: 'entry',
-        targets: {
-          browsers,
+      Object.assign(
+        {
+          useBuiltIns: 'entry',
+          corejs: '3.0.0',
+          targets: {
+            browsers,
+          },
         },
-      },
+        envOption
+      ),
     ],
   ];
 

--- a/packages/babel-preset-beidou-client/test/babel-client.test.js
+++ b/packages/babel-preset-beidou-client/test/babel-client.test.js
@@ -32,4 +32,14 @@ describe('babel-preset-client', () => {
     assert.equal(typeof result.presets[1][1], 'object');
   });
 
+  it('should overrite defalt env config', () => {
+    assert(typeof preset === 'function');
+    const result = preset(mockApi, { env: {
+      corejs: '2.0.0',
+    } });
+    assert(Array.isArray(result.presets));
+    assert.equal(typeof result.presets[0][1], 'object');
+    assert.equal(result.presets[0][1].corejs, '2.0.0');
+  });
+
 });


### PR DESCRIPTION
Solved the warning: 
```
WARNING: We noticed you're using the `useBuiltIns` option without declaring a core-js version. Currently, we assume version 2.x when no version is passed. Since this default version will likely change in future versions of Babel, we recommend explicitly setting the core-js version you are using via the `corejs` option.

You should also be sure that the version you pass to the `corejs` option matches the version specified in your `package.json`'s `dependencies` section. If it doesn't, you need to run one of the following commands:

  npm install --save core-js@2    npm install --save core-js@3
  yarn add core-js@2              yarn add core-js@3
```


## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

* [x] `npm test` passes
* [x] tests are included
* [x] documentation is changed or added
* [x] commit message follows commit guidelines

## Affected plugin(s)

- babel-preset-beidou-client

## Description of change

for preset-env:
 - set corejs default to `3.0.0`
 - support custom config
