### PR TITLE
fix: tar vulnerability

### DIFF
--- a/packages/beidou-cli/lib/commands/init.js
+++ b/packages/beidou-cli/lib/commands/init.js
@@ -4,7 +4,6 @@ const os = require('os');
 const fs = require('fs');
 const path = require('path');
 const rimraf = require('rimraf');
-const zlib = require('zlib');
 const tar = require('tar');
 const urllib = require('urllib');
 const updater = require('npm-updater');
@@ -300,6 +299,7 @@ module.exports = class InitCMD extends Command {
   async downloadAndUnzip(url, saveDir) {
     await new Promise((resolve, reject) => {
       rimraf.sync(saveDir);
+      fs.mkdirSync(saveDir);
       function handleError(err) {
         rimraf.sync(saveDir);
         reject(err);
@@ -316,14 +316,11 @@ module.exports = class InitCMD extends Command {
             return reject(err);
           }
 
-          const gunzip = zlib.createGunzip();
-          gunzip.on('error', handleError);
-
-          const extractor = tar.Extract({ path: saveDir, strip: 1 });
+          const extractor = tar.x({ C: saveDir, strip: 1 });
           extractor.on('error', handleError);
           extractor.on('end', resolve);
 
-          res.pipe(gunzip).pipe(extractor);
+          res.pipe(extractor);
         }
       );
     });

--- a/packages/beidou-cli/package.json
+++ b/packages/beidou-cli/package.json
@@ -29,7 +29,7 @@
     "mkdirp": "^0.5.1",
     "npm-updater": "^3.0.3",
     "rimraf": "^2.6.2",
-    "tar": "^2.2.1",
+    "tar": "^4.4.2",
     "urllib": "^2.25.4"
   },
   "boilerplates": {


### PR DESCRIPTION

tar vulnerability fix for: https://nvd.nist.gov/vuln/detail/CVE-2018-20834

* [ ] `npm test` passes
* [ ] commit message follows commit guidelines

## Affected plugin(s)

- beidou-cli

## Description of change

upgrade tar dependency to `^4.4.2`
