### PR TITLE
bugfix: revise the key 'browserlist' of autoprefixer config in 9.6.0

### DIFF
--- a/packages/beidou-webpack/config/webpack/utils.js
+++ b/packages/beidou-webpack/config/webpack/utils.js
@@ -53,7 +53,8 @@ const postCssLoaderConfig = {
     plugins: () => [
       require('postcss-flexbugs-fixes'),
       autoprefixer({
-        browserslist: ['>1%', 'last 4 versions', 'Firefox ESR', 'not ie < 9'],
+        overrideBrowserslist:
+          ['>1%', 'last 4 versions', 'Firefox ESR', 'not ie < 9'],
         flexbox: 'no-2009',
       }),
     ],

--- a/packages/beidou-webpack/config/webpack/utils.js
+++ b/packages/beidou-webpack/config/webpack/utils.js
@@ -53,7 +53,7 @@ const postCssLoaderConfig = {
     plugins: () => [
       require('postcss-flexbugs-fixes'),
       autoprefixer({
-        browsers: ['>1%', 'last 4 versions', 'Firefox ESR', 'not ie < 9'],
+        browserslist: ['>1%', 'last 4 versions', 'Firefox ESR', 'not ie < 9'],
         flexbox: 'no-2009',
       }),
     ],

--- a/packages/beidou-webpack/package.json
+++ b/packages/beidou-webpack/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@babel/core": "^7.1.2",
     "argh": "^0.1.4",
-    "autoprefixer": "^9.4.4",
+    "autoprefixer": "^9.6.0",
     "babel-core": "^6.26.0",
     "babel-loader": "^8.0.4",
     "babel-minify-webpack-plugin": "^0.3.1",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly docs.
Contributors guide: https://github.com/alibaba/beidou/blob/master/.github/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上文档。
Contributors guide: https://github.com/alibaba/beidou/blob/master/.github/CONTRIBUTING.zh-CN.md
-->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

* [x] `npm test` passes
* [x] tests are included
* [x] documentation is changed or added
* [x] commit message follows commit guidelines

## Description of change

In 9.6.0 version of autoprefixer , the key `browers` was changed to `browserlist`.
see it : https://github.com/postcss/autoprefixer/releases/tag/9.6.0
