### PR TITLE
bugfix: add config for css min extract

### DIFF
--- a/packages/beidou-webpack/CHANGELOG.md
+++ b/packages/beidou-webpack/CHANGELOG.md
@@ -5,25 +5,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [2.1.0](https://github.com/alibaba/beidou/tree/master/packages/beidou-webpack/compare/v2.0.5...v2.1.0) (2019-04-26)
 
-
 ### Features
 
-* enable contenthash for assets ([#161](https://github.com/alibaba/beidou/tree/master/packages/beidou-webpack/issues/161)) ([b2fdb07](https://github.com/alibaba/beidou/tree/master/packages/beidou-webpack/commit/b2fdb07))
-
-
-
-
+- enable contenthash for assets ([#161](https://github.com/alibaba/beidou/tree/master/packages/beidou-webpack/issues/161)) ([b2fdb07](https://github.com/alibaba/beidou/tree/master/packages/beidou-webpack/commit/b2fdb07))
 
 ## [2.0.2](https://github.com/alibaba/beidou/tree/master/packages/beidou-webpack/compare/v2.0.1...v2.0.2) (2019-02-27)
 
-
 ### Bug Fixes
 
-* disable exract comments ([#149](https://github.com/alibaba/beidou/tree/master/packages/beidou-webpack/issues/149)) ([a0b7025](https://github.com/alibaba/beidou/tree/master/packages/beidou-webpack/commit/a0b7025))
-
-
-
-
+- disable exract comments ([#149](https://github.com/alibaba/beidou/tree/master/packages/beidou-webpack/issues/149)) ([a0b7025](https://github.com/alibaba/beidou/tree/master/packages/beidou-webpack/commit/a0b7025))
 
 # [2.0.0](https://github.com/alibaba/beidou/tree/master/packages/beidou-webpack/compare/v1.2.1...v2.0.0) (2019-01-16)
 

--- a/packages/beidou-webpack/README-ZH.md
+++ b/packages/beidou-webpack/README-ZH.md
@@ -37,6 +37,7 @@ exports.webpack = {
   custom: {
     // configPath: 'path/to/webpack/config/file',
     depth: 1,
+    cssExtract: true, // 是否默认使用 mini-css-extract-plugin 抽离css文件
   },
   output: {
     path: './build',
@@ -153,6 +154,8 @@ module.exports = {
 ```
 
 上述配置下，以 `/foo` 开头的所有请求均会直接转发给 webpack，用于使用了 devServer.proxy 的场景
+
+**custom.cssExtract**: 是否开启css抽离插件
 
 ### 常见配置问题
 

--- a/packages/beidou-webpack/README.md
+++ b/packages/beidou-webpack/README.md
@@ -40,6 +40,7 @@ exports.webpack = {
     // configPath: 'path/to/webpack/config/file',
     // depth: 1,
     // proxy: null,
+    cssExtract: true,  // default enable css-mini-plugin config
   },
   output: {
     path: './build',
@@ -155,9 +156,11 @@ e.g.：
 
 All of the requests start with `/foo` will be redirected to webpack server directly. Useful when enable devServer.proxy.
 
+**custom.cssExtract**: whether enable css-mini-plugin for webpack
+
 #### FAQ:
 
-使用配置工厂自定义配置项,操作方式如下例
+Custom configurate method by `app.webpackFactory`:
 
 ```js
 

--- a/packages/beidou-webpack/config/config.default.js
+++ b/packages/beidou-webpack/config/config.default.js
@@ -7,6 +7,7 @@ module.exports = appInfo => ({
     // keep this key name sync with webpack.common.js reservedKey
     custom: {
       depth: 1,
+      cssExtract: true,
       // configPath: 'path/to/webpack/config/file',
     },
     mode: 'development',

--- a/packages/beidou-webpack/config/webpack/utils.js
+++ b/packages/beidou-webpack/config/webpack/utils.js
@@ -69,84 +69,112 @@ const lessLoaderConfig = {
 };
 
 
-const getMiniCssExtractConfig = (dev, options) => (options.cssExtract ?
-  { loader: MiniCssExtractPlugin.loader,
+function getStyleCongfigs(dev, options) {
+  const extractLoader = { loader: MiniCssExtractPlugin.loader,
     options: {
       hmr: dev,
     },
-  } : {
+  };
+  const styleLoader = {
     loader: require.resolve('style-loader'),
     options: {
       hmr: dev,
     },
-  }
-);
+  };
+
+  const defaultLoader = options.cssExtract ? extractLoader : styleLoader;
+
+  const dynamicProcessor = (rule) => {
+    const use = rule.use.slice(1);
+
+    rule.processor = function (factory) {
+      if (factory.cssExtract === undefined) {
+        return {};
+      }
+      if (factory.cssExtract) {
+        return {
+          use: [
+            extractLoader,
+            ...use,
+          ],
+        };
+      } else {
+        return {
+          use: [
+            styleLoader,
+            ...use,
+          ],
+        };
+      }
+    };
+
+    return rule;
+  };
 
 
-function getStyleCongfigs(dev, options) {
   const loaders = [
-    {
+    dynamicProcessor({
       test: /\.css$/,
       exclude: /\.m(odule)?\.css$/,
       use: [
-        getMiniCssExtractConfig(dev, options),
+        defaultLoader,
         getCssLoaderConfig(dev),
         postCssLoaderConfig,
       ],
-    },
-    {
+    }),
+    dynamicProcessor({
       test: /\.m(odule)?\.css$/,
       use: [
-        getMiniCssExtractConfig(dev, options),
+        defaultLoader,
         getCssLoaderConfig(dev, true),
         postCssLoaderConfig,
       ],
-    },
-    {
+    }),
+    dynamicProcessor({
       test: /\.less$/,
       exclude: /\.m(odule)?\.less$/,
       use: [
-        getMiniCssExtractConfig(dev, options),
+        defaultLoader,
         getCssLoaderConfig(dev),
         postCssLoaderConfig,
         lessLoaderConfig,
       ],
-    },
-    {
+    }),
+    dynamicProcessor({
       test: /\.m(odule)?\.less$/,
       use: [
-        getMiniCssExtractConfig(dev, options),
+        defaultLoader,
         getCssLoaderConfig(dev, true),
         postCssLoaderConfig,
         lessLoaderConfig,
       ],
-    },
+    }),
   ];
   if (requirePeer.resolve('sass-loader').isValid) {
     return loaders.concat([
-      {
+      dynamicProcessor({
         test: /\.s(c|a)ss$/,
         exclude: /\.m(odule)?\.s(c|a)ss$/,
         use: [
-          getMiniCssExtractConfig(dev, options),
+          defaultLoader,
           getCssLoaderConfig(dev),
           postCssLoaderConfig,
           {
             loader: require.resolve('sass-loader'),
           },
         ],
-      },
-      {
+      }),
+      dynamicProcessor({
         test: /\.m(odule)?\.s(c|a)ss$/,
         use: [
-          getMiniCssExtractConfig(dev, options),
+          defaultLoader,
           getCssLoaderConfig(dev, true),
           postCssLoaderConfig,
           {
             loader: require.resolve('sass-loader'),
           },
         ],
-      },
+      }),
     ]);
   }
 

--- a/packages/beidou-webpack/config/webpack/utils.js
+++ b/packages/beidou-webpack/config/webpack/utils.js
@@ -68,18 +68,28 @@ const lessLoaderConfig = {
   },
 };
 
-function getStyleCongfigs(dev) {
+
+const getMiniCssExtractConfig = (dev, options) => (options.cssExtract ?
+  { loader: MiniCssExtractPlugin.loader,
+    options: {
+      hmr: dev,
+    },
+  } : {
+    loader: require.resolve('style-loader'),
+    options: {
+      hmr: dev,
+    },
+  }
+);
+
+
+function getStyleCongfigs(dev, options) {
   const loaders = [
     {
       test: /\.css$/,
       exclude: /\.m(odule)?\.css$/,
       use: [
-        {
-          loader: MiniCssExtractPlugin.loader,
-          options: {
-            hmr: dev,
-          },
-        },
+        getMiniCssExtractConfig(dev, options),
         getCssLoaderConfig(dev),
         postCssLoaderConfig,
       ],
@@ -87,12 +97,7 @@ function getStyleCongfigs(dev) {
     {
       test: /\.m(odule)?\.css$/,
       use: [
-        {
-          loader: MiniCssExtractPlugin.loader,
-          options: {
-            hmr: dev,
-          },
-        },
+        getMiniCssExtractConfig(dev, options),
         getCssLoaderConfig(dev, true),
         postCssLoaderConfig,
       ],
@@ -101,12 +106,7 @@ function getStyleCongfigs(dev) {
       test: /\.less$/,
       exclude: /\.m(odule)?\.less$/,
       use: [
-        {
-          loader: MiniCssExtractPlugin.loader,
-          options: {
-            hmr: dev,
-          },
-        },
+        getMiniCssExtractConfig(dev, options),
         getCssLoaderConfig(dev),
         postCssLoaderConfig,
         lessLoaderConfig,
@@ -115,12 +115,7 @@ function getStyleCongfigs(dev) {
     {
       test: /\.m(odule)?\.less$/,
       use: [
-        {
-          loader: MiniCssExtractPlugin.loader,
-          options: {
-            hmr: dev,
-          },
-        },
+        getMiniCssExtractConfig(dev, options),
         getCssLoaderConfig(dev, true),
         postCssLoaderConfig,
         lessLoaderConfig,
@@ -133,12 +128,7 @@ function getStyleCongfigs(dev) {
         test: /\.s(c|a)ss$/,
         exclude: /\.m(odule)?\.s(c|a)ss$/,
         use: [
-          {
-            loader: MiniCssExtractPlugin.loader,
-            options: {
-              hmr: dev,
-            },
-          },
+          getMiniCssExtractConfig(dev, options),
           getCssLoaderConfig(dev),
           postCssLoaderConfig,
           {
@@ -149,12 +139,7 @@ function getStyleCongfigs(dev) {
       {
         test: /\.m(odule)?\.s(c|a)ss$/,
         use: [
-          {
-            loader: MiniCssExtractPlugin.loader,
-            options: {
-              hmr: dev,
-            },
-          },
+          getMiniCssExtractConfig(dev, options),
           getCssLoaderConfig(dev, true),
           postCssLoaderConfig,
           {

--- a/packages/beidou-webpack/config/webpack/webpack.browser.js
+++ b/packages/beidou-webpack/config/webpack/webpack.browser.js
@@ -22,6 +22,7 @@ module.exports = (app, entry, dev) => {
   const viewConfig = app.config.view;
   const { custom } = app.config.webpack;
   common(app, entry, dev);
+
   [
     {
       test: /\.(js|jsx|ts|tsx|mjs)$/,

--- a/packages/beidou-webpack/config/webpack/webpack.browser.js
+++ b/packages/beidou-webpack/config/webpack/webpack.browser.js
@@ -20,6 +20,7 @@ module.exports = (app, entry, dev) => {
   const factory = app.webpackFactory;
   const typescript = pkg && pkg.config && pkg.config.typescript;
   const viewConfig = app.config.view;
+  const { custom } = app.config.webpack;
   common(app, entry, dev);
   [
     {
@@ -41,15 +42,21 @@ module.exports = (app, entry, dev) => {
         },
       },
     },
-    ...getStyleCongfigs(dev),
+    ...getStyleCongfigs(dev, {
+      cssExtract: custom.cssExtract,
+    }),
     imageLoaderConfig,
     fileLoaderConfig,
   ].forEach(v => factory.defineRule(v).addRule(v));
 
   factory
-    .definePlugin(MiniCssExtractPlugin, {
-      filename: '[name].css',
-    }, 'MiniCssExtractPlugin')
+    .definePlugin(
+      MiniCssExtractPlugin,
+      {
+        filename: '[name].css',
+      },
+      'MiniCssExtractPlugin'
+    )
     .definePlugin(
       webpack.DefinePlugin,
       {
@@ -93,7 +100,10 @@ module.exports = (app, entry, dev) => {
       'HotModuleReplacementPlugin'
     );
   }
-  factory.addPlugin('MiniCssExtractPlugin');
+  if (custom.cssExtract) {
+    factory.addPlugin('MiniCssExtractPlugin');
+  }
+
   if (viewConfig && viewConfig.useHashAsset && !dev) {
     factory.addPlugin(
       ManifestPlugin,

--- a/packages/beidou-webpack/config/webpack/webpack.node.js
+++ b/packages/beidou-webpack/config/webpack/webpack.node.js
@@ -15,6 +15,7 @@ const {
 module.exports = (app, entry, dev) => {
   const factory = app.webpackFactory;
   const viewConfig = app.config.view;
+  const { custom } = app.config.webpack;
   common(app, entry, dev);
   factory.get('output').libraryTarget = 'commonjs';
   factory.set('target', 'node');
@@ -41,7 +42,9 @@ module.exports = (app, entry, dev) => {
         },
       },
     },
-    ...getStyleCongfigs(dev),
+    ...getStyleCongfigs(dev, {
+      cssExtract: custom.cssExtract,
+    }),
     imageLoaderConfig,
     fileLoaderConfig,
   ].forEach((v) => {
@@ -56,12 +59,18 @@ module.exports = (app, entry, dev) => {
       'MiniCssExtractPlugin'
     );
   } else {
-    factory.definePlugin(MiniCssExtractPlugin, {
-      filename: '[name].css',
-    }, 'MiniCssExtractPlugin');
+    factory.definePlugin(
+      MiniCssExtractPlugin,
+      {
+        filename: '[name].css',
+      },
+      'MiniCssExtractPlugin'
+    );
   }
 
-  factory.addPlugin('MiniCssExtractPlugin');
+  if (custom.cssExtract) {
+    factory.addPlugin('MiniCssExtractPlugin');
+  }
 
   factory.definePlugin(
     webpack.DefinePlugin,

--- a/packages/beidou-webpack/config/webpack/webpack.node.js
+++ b/packages/beidou-webpack/config/webpack/webpack.node.js
@@ -50,6 +50,7 @@ module.exports = (app, entry, dev) => {
   ].forEach((v) => {
     factory.defineRule(v).addRule(v);
   });
+
   if (!dev && viewConfig.useHashAsset) {
     factory.definePlugin(
       MiniCssExtractPlugin,

--- a/packages/beidou-webpack/lib/factory/rule.js
+++ b/packages/beidou-webpack/lib/factory/rule.js
@@ -9,7 +9,13 @@ class Rule {
     this.alias = alias || options.test;
   }
 
-  init() {
+  toConfig(factory) {
+    if (this.options.processor) {
+      const dynamicOptions = this.options.processor(factory);
+      const options = Object.assign({}, this.options, dynamicOptions);
+      delete options.processor;
+      return options;
+    }
     return this.options;
   }
 }

--- a/packages/beidou-webpack/lib/factory/webpack.js
+++ b/packages/beidou-webpack/lib/factory/webpack.js
@@ -14,6 +14,7 @@ function toType(obj) {
 
 class Factory {
   init() {
+    this.cssExtract = undefined;
     this.__envFactories = {};
     this.__defineloaders = {};
     this.__definePlugins = {};
@@ -76,7 +77,7 @@ class WebpackFactory extends Factory {
   getRuleConfig() {
     const rules = [];
     this.__rules.forEach((v) => {
-      rules.push(v.options);
+      rules.push(v.toConfig(this));
     });
     return rules;
   }

--- a/packages/beidou-webpack/lib/factory/webpack.js
+++ b/packages/beidou-webpack/lib/factory/webpack.js
@@ -6,7 +6,10 @@ const Rule = require('./rule');
 const extend = require('extend2');
 
 function toType(obj) {
-  return ({}).toString.call(obj).match(/\s([a-zA-Z]+)/)[1].toLowerCase();
+  return {}.toString
+    .call(obj)
+    .match(/\s([a-zA-Z]+)/)[1]
+    .toLowerCase();
 }
 
 class Factory {
@@ -105,7 +108,11 @@ class WebpackFactory extends Factory {
     if (force || is.string(config)) {
       this.__webpackConfig[key] = config;
     } else if (is.object(config)) {
-      this.__webpackConfig[key] = extend(true, this.__webpackConfig[key], config);
+      this.__webpackConfig[key] = extend(
+        true,
+        this.__webpackConfig[key],
+        config
+      );
     } else if (is.array(config)) {
       this.__webpackConfig[key] = this.__webpackConfig[key].concat(config);
     }

--- a/packages/beidou-webpack/lib/utils/index.js
+++ b/packages/beidou-webpack/lib/utils/index.js
@@ -155,8 +155,8 @@ const getWebpackConfig = (app, options = {}, target = 'browser') => {
   if (devServer.contentBase !== false) {
     app.logger.warn(
       '[webpack] devServer.contentBase: %s, if ' +
-      'webpack.devServer.contentBase is not false may cause beidou' +
-      ' server unreachable',
+        'webpack.devServer.contentBase is not false may cause beidou' +
+        ' server unreachable',
       devServer.contentBase
     );
     devServer.contentBase = false;

--- a/packages/beidou-webpack/test/fixtures/custom-webpack-css-extract/client/example/component.jsx
+++ b/packages/beidou-webpack/test/fixtures/custom-webpack-css-extract/client/example/component.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import classNames from 'classnames/bind';
+import style from './index.scss';
+
+const cx = classNames.bind(style);
+
+export default class Index extends React.Component {
+  constructor() {
+    super();
+    this.state = {};
+  }
+
+  componentWillMount() {
+    this.setState({
+      desc: 'css modules',
+    });
+  }
+
+  render() {
+    return (
+      <div className={cx('page')}>
+        <h3>
+          This is example page, back to <a href="/">index page</a>
+        </h3>
+        <p>{this.state.desc}</p>
+      </div>
+    );
+  }
+}

--- a/packages/beidou-webpack/test/fixtures/custom-webpack-css-extract/client/example/index.jsx
+++ b/packages/beidou-webpack/test/fixtures/custom-webpack-css-extract/client/example/index.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import App from './component';
+
+/**
+ * custom view template
+ *
+ * @export
+ * @class View
+ * @extends {React.Component}
+ */
+export default class View extends React.Component {
+  render() {
+    return (
+      <html>
+        <head>
+          <title>Example</title>
+          <link rel="stylesheet" href="/build/example.css" />
+        </head>
+        <body>
+          <div id="container" />
+          <script src={'/build/manifest.js'} />
+          <script src={'/build/example.js'} />
+        </body>
+      </html>
+    );
+  }
+}

--- a/packages/beidou-webpack/test/fixtures/custom-webpack-css-extract/client/example/index.scss
+++ b/packages/beidou-webpack/test/fixtures/custom-webpack-css-extract/client/example/index.scss
@@ -1,0 +1,10 @@
+h3 {
+  color: red;
+}
+
+.bg {
+  margin: 32px;
+}
+.page {
+  background: #f0f0f0;
+}

--- a/packages/beidou-webpack/test/fixtures/custom-webpack-css-extract/client/index.js
+++ b/packages/beidou-webpack/test/fixtures/custom-webpack-css-extract/client/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+class Index extends React.Component {
+  render() {
+    return null;
+  }
+}
+
+export default Index;

--- a/packages/beidou-webpack/test/fixtures/custom-webpack-css-extract/config/config.default.js
+++ b/packages/beidou-webpack/test/fixtures/custom-webpack-css-extract/config/config.default.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const path = require('path');
+
+module.exports = function () {
+  const exports = {};
+
+  exports.webpack = {
+    custom: {
+      configPath: path.resolve(__dirname, '../webpack/custom.webpack.config.js'),
+      cssExtract: false
+    },
+  };
+
+  return exports;
+};

--- a/packages/beidou-webpack/test/fixtures/custom-webpack-css-extract/config/plugin.js
+++ b/packages/beidou-webpack/test/fixtures/custom-webpack-css-extract/config/plugin.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.webpack = true;

--- a/packages/beidou-webpack/test/fixtures/custom-webpack-css-extract/package.json
+++ b/packages/beidou-webpack/test/fixtures/custom-webpack-css-extract/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "webpack-server",
+  "spm": {
+    "less": true
+  }
+}

--- a/packages/beidou-webpack/test/fixtures/custom-webpack-css-extract/webpack/custom.webpack.config.js
+++ b/packages/beidou-webpack/test/fixtures/custom-webpack-css-extract/webpack/custom.webpack.config.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const path = require('path');
+const webpack = require('webpack');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+
+module.exports = (app, defaultConfig, entry, isDev) => {
+  const outputPath = path.join(app.config.baseDir, 'build');
+  const factory = app.webpackFactory;
+
+  factory.reset({
+    devtool: 'source-map',
+    context: path.resolve(__dirname, '..'),
+    entry: factory.getConfig().entry,
+    output: {
+      path: outputPath,
+      filename: '[name].js?[hash]',
+      chunkFilename: '[name].js',
+      publicPath: '/build/',
+    },
+    module: {
+      "strictExportPresence": true,
+    },
+    resolve: {
+      extensions: ['.json', '.js', '.jsx'],
+      alias: {
+        "client": "../client"
+      },
+    },
+    devServer: {
+      publicPath: '/build',
+    }
+  });
+
+  return factory.getConfig();
+
+
+};

--- a/packages/beidou-webpack/test/fixtures/factory-webpack-css-extract/client/example/component.jsx
+++ b/packages/beidou-webpack/test/fixtures/factory-webpack-css-extract/client/example/component.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import classNames from 'classnames/bind';
+import style from './index.scss';
+
+const cx = classNames.bind(style);
+
+export default class Index extends React.Component {
+  constructor() {
+    super();
+    this.state = {};
+  }
+
+  componentWillMount() {
+    this.setState({
+      desc: 'css modules',
+    });
+  }
+
+  render() {
+    return (
+      <div className={cx('page')}>
+        <h3>
+          This is example page, back to <a href="/">index page</a>
+        </h3>
+        <p>{this.state.desc}</p>
+      </div>
+    );
+  }
+}

--- a/packages/beidou-webpack/test/fixtures/factory-webpack-css-extract/client/example/index.jsx
+++ b/packages/beidou-webpack/test/fixtures/factory-webpack-css-extract/client/example/index.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import App from './component';
+
+/**
+ * custom view template
+ *
+ * @export
+ * @class View
+ * @extends {React.Component}
+ */
+export default class View extends React.Component {
+  render() {
+    return (
+      <html>
+        <head>
+          <title>Example</title>
+          <link rel="stylesheet" href="/build/example.css" />
+        </head>
+        <body>
+          <div id="container" />
+          <script src={'/build/manifest.js'} />
+          <script src={'/build/example.js'} />
+        </body>
+      </html>
+    );
+  }
+}

--- a/packages/beidou-webpack/test/fixtures/factory-webpack-css-extract/client/example/index.scss
+++ b/packages/beidou-webpack/test/fixtures/factory-webpack-css-extract/client/example/index.scss
@@ -1,0 +1,10 @@
+h3 {
+  color: red;
+}
+
+.bg {
+  margin: 32px;
+}
+.page {
+  background: #f0f0f0;
+}

--- a/packages/beidou-webpack/test/fixtures/factory-webpack-css-extract/client/index.js
+++ b/packages/beidou-webpack/test/fixtures/factory-webpack-css-extract/client/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+class Index extends React.Component {
+  render() {
+    return null;
+  }
+}
+
+export default Index;

--- a/packages/beidou-webpack/test/fixtures/factory-webpack-css-extract/config/config.default.js
+++ b/packages/beidou-webpack/test/fixtures/factory-webpack-css-extract/config/config.default.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const path = require('path');
+
+module.exports = function () {
+  const exports = {};
+
+  exports.webpack = {
+    custom: {
+      configPath: path.resolve(__dirname, '../webpack/custom.webpack.config.js'),
+      cssExtract: true
+    },
+  };
+
+  return exports;
+};

--- a/packages/beidou-webpack/test/fixtures/factory-webpack-css-extract/config/plugin.js
+++ b/packages/beidou-webpack/test/fixtures/factory-webpack-css-extract/config/plugin.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.webpack = true;

--- a/packages/beidou-webpack/test/fixtures/factory-webpack-css-extract/package.json
+++ b/packages/beidou-webpack/test/fixtures/factory-webpack-css-extract/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "webpack-server",
+  "spm": {
+    "less": true
+  }
+}

--- a/packages/beidou-webpack/test/fixtures/factory-webpack-css-extract/webpack/custom.webpack.config.js
+++ b/packages/beidou-webpack/test/fixtures/factory-webpack-css-extract/webpack/custom.webpack.config.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const path = require('path');
+const webpack = require('webpack');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+
+module.exports = (app, defaultConfig, entry, isDev) => {
+  const outputPath = path.join(app.config.baseDir, 'build');
+  const factory = app.webpackFactory;
+
+  factory.cssExtract = false;
+
+  factory.reset({
+    devtool: 'source-map',
+    context: path.resolve(__dirname, '..'),
+    entry: factory.getConfig().entry,
+    output: {
+      path: outputPath,
+      filename: '[name].js?[hash]',
+      chunkFilename: '[name].js',
+      publicPath: '/build/',
+    },
+    module: {
+      "strictExportPresence": true,
+    },
+    resolve: {
+      extensions: ['.json', '.js', '.jsx'],
+      alias: {
+        "client": "../client"
+      },
+    },
+    devServer: {
+      publicPath: '/build',
+    }
+  });
+
+  return factory.getConfig();
+
+
+};

--- a/packages/beidou-webpack/test/lib/factory/rule.test.js
+++ b/packages/beidou-webpack/test/lib/factory/rule.test.js
@@ -17,6 +17,5 @@ describe('test/lib/factory/rule.test.js', () => {
       test:'js'
     })
     assert(ruleObj,'init rule error');
-    assert(ruleObj.init().test === 'js','get rule options error')
   })
 })

--- a/packages/beidou-webpack/test/webpack.test.js
+++ b/packages/beidou-webpack/test/webpack.test.js
@@ -161,7 +161,7 @@ describe('test/webpack.test.js', () => {
     });
   })
 
-  describe.only('customer webpack config => disable css mini plugin', () => {
+  describe('customer webpack config => disable css mini plugin', () => {
     let app;
     const output = path.join(__dirname, './fixtures/custom-webpack-css-extract/build');
     before((done) => {

--- a/packages/beidou-webpack/test/webpack.test.js
+++ b/packages/beidou-webpack/test/webpack.test.js
@@ -161,6 +161,45 @@ describe('test/webpack.test.js', () => {
     });
   })
 
+  describe.only('customer webpack config => disable css mini plugin', () => {
+    let app;
+    const output = path.join(__dirname, './fixtures/custom-webpack-css-extract/build');
+    before((done) => {
+      app = mm.app({
+        baseDir: './custom-webpack-css-extract',
+        plugin,
+        framework,
+      });
+      app.ready(() => {
+        const builder = require('../lib/builder');
+        app.config.env = 'prod';
+        const compiler = builder(app);
+        compiler.run(done);
+      });
+    });
+
+    after((done) => {
+      if (fs.existsSync(output)) {
+        rimraf(output, done);
+      }
+      app.close();
+      app.agent.close();
+    });
+
+    afterEach(mm.restore);
+
+    it('should exist build files', (done) => {
+      const exist = fs.existsSync(path.join(output, 'index.js'));
+      expect(exist).to.equal(true);
+      done();
+    });
+
+    it('should disable the css module plugin ', (done) => {
+      const example = fs.existsSync(path.join(output, 'example.css'));
+      expect(example).to.equal(false);
+      done();
+    });
+  })
 
   describe('config publicPath', () => {
     let app;

--- a/packages/beidou-webpack/test/webpack.test.js
+++ b/packages/beidou-webpack/test/webpack.test.js
@@ -201,6 +201,46 @@ describe('test/webpack.test.js', () => {
     });
   })
 
+  describe('customer webpack config => disable css mini plugin with factory', () => {
+    let app;
+    const output = path.join(__dirname, './fixtures/factory-webpack-css-extract/build');
+    before((done) => {
+      app = mm.app({
+        baseDir: './factory-webpack-css-extract',
+        plugin,
+        framework,
+      });
+      app.ready(() => {
+        const builder = require('../lib/builder');
+        app.config.env = 'prod';
+        const compiler = builder(app);
+        compiler.run(done);
+      });
+    });
+
+    after((done) => {
+      if (fs.existsSync(output)) {
+        rimraf(output, done);
+      }
+      app.close();
+      app.agent.close();
+    });
+
+    afterEach(mm.restore);
+
+    it('should exist build files', (done) => {
+      const exist = fs.existsSync(path.join(output, 'index.js'));
+      expect(exist).to.equal(true);
+      done();
+    });
+
+    it('should disable the css module plugin ', (done) => {
+      const example = fs.existsSync(path.join(output, 'example.css'));
+      expect(example).to.equal(false);
+      done();
+    });
+  })
+
   describe('config publicPath', () => {
     let app;
     before((done) => {


### PR DESCRIPTION
## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

* [x] `npm test` passes
* [x] tests are included
* [x] documentation is changed or added
* [x] commit message follows commit guidelines

## Affected plugin(s)

* beidou-webpack

## Description of change

在beidou-webpack中，增加custom.cssExtract配置项，标识是否进行css样式抽离配置CssMinPlugin . 默认值为 true
