### PR TITLE
fix(webpack): optinal peer deps semver & factory rule get

### DIFF
--- a/packages/beidou-view/test/view.test.js
+++ b/packages/beidou-view/test/view.test.js
@@ -24,11 +24,12 @@ describe('test/view.test.js', () => {
   describe('Base view', () => {
     let app;
 
-    before(() => {
+    before((done) => {
       app = mock.app({
         baseDir: './base-app',
         framework,
       });
+      app.ready(done);
     });
     after(() => {
       app.close();

--- a/packages/beidou-webpack/lib/factory/webpack.js
+++ b/packages/beidou-webpack/lib/factory/webpack.js
@@ -244,7 +244,25 @@ class WebpackFactory extends Factory {
   getRule(params) {
     if (is.string(params)) {
       return this.__rules.find(
-        v => v.alias === params || v.options.test.test(params) === true
+        v => {
+          if (v.alias === params) {
+            return true;
+          }
+          if (v.options && v.options.test) {
+            const regexps = v.options.test;
+
+            if (Array.isArray(regexps)) {
+              for (const regexp of regexps) {
+                if (regexp.test && regexp.test(params)) {
+                  return true;
+                }
+              }
+            } else if (regexps instanceof RegExp && regexps.test(params)) {
+              return true;
+            }
+          }
+          return false;
+        }
       );
     } else if (is.function(params)) {
       for (const rule of this.__rules) {

--- a/packages/beidou-webpack/package.json
+++ b/packages/beidou-webpack/package.json
@@ -72,8 +72,8 @@
     "beidou-core": "^1.0.10"
   },
   "optionalPeerDependencies": {
-    "node-sass": "^4.5.3",
-    "sass-loader": "^7.0.0"
+    "node-sass": ">=4.0.0",
+    "sass-loader": ">=7.0.0"
   },
   "files": [
     "bin",

--- a/packages/beidou-webpack/test/lib/factory/webpack.test.js
+++ b/packages/beidou-webpack/test/lib/factory/webpack.test.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const webpack = require('webpack');
 const WebpackFactory = require('../../../lib/factory/webpack');
 
-describe.only('test/lib/factory/webpack.test.js', () => {
+describe('test/lib/factory/webpack.test.js', () => {
   const factory = new WebpackFactory({
     'testArr': ['foo', 'bar'],
     'testObj': {

--- a/packages/beidou-webpack/test/lib/factory/webpack.test.js
+++ b/packages/beidou-webpack/test/lib/factory/webpack.test.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const webpack = require('webpack');
 const WebpackFactory = require('../../../lib/factory/webpack');
 
-describe('test/lib/factory/webpack.test.js', () => {
+describe.only('test/lib/factory/webpack.test.js', () => {
   const factory = new WebpackFactory({
     'testArr': ['foo', 'bar'],
     'testObj': {
@@ -142,6 +142,14 @@ describe('test/lib/factory/webpack.test.js', () => {
       'js')
     rule = factory.getRule('jsx')
     assert(!rule, 'the rule shuld undefined');
+
+    factory.setRule({
+      test: [/\.png$/, /\.jpg/],
+      exclude: /node_modules/
+    }, 'image');
+
+    rule = factory.getRule('.jpg');
+    assert(rule, 'should get rule if test is array');
   })
 
   it('generate env config ', () => {


### PR DESCRIPTION
## Checklist

* [x] `npm test` passes
* [x] tests are included
* [x] documentation is changed or added
* [x] commit message follows commit guidelines

## Affected plugin(s)

- beidou-webpack

## Description of change

- fix optionalPeerDependencies
- fix webpack factory.getRule() when options.test is an array of RegExp
