### PR TITLE
feat: 支持webpack自定义扩展

### DIFF
--- a/packages/beidou-cli/lib/commands/build.js
+++ b/packages/beidou-cli/lib/commands/build.js
@@ -9,7 +9,6 @@ const {
   getArgvWithDefaultFramework = 'beidou',
   framework,
   cmdName,
-  webpack = 'beidou-webpack'
 } = require('../helper');
 
 module.exports = class BuildCMD extends Command {
@@ -31,10 +30,12 @@ module.exports = class BuildCMD extends Command {
   }
 
   async run(context) {
+    const wpconfig = context.argv.webpack || 'beidou-webpack'
+
     const buildPaths = [
-      path.join(context.cwd, `node_modules/${webpack}/bin/build.js`),
-      path.join(__dirname, `../../../${webpack}/bin/build.js`),
-      () => require.resolve(`${webpack}/bin/build`),
+      path.join(context.cwd, `node_modules/${wpconfig}/bin/build.js`),
+      path.join(__dirname, `../../../${wpconfig}/bin/build.js`),
+      () => require.resolve(`${wpconfig}/bin/build`),
     ];
     const buildBin = buildPaths.find(p =>
       fs.existsSync(typeof p === 'function' ? p() : p)

--- a/packages/beidou-cli/lib/commands/build.js
+++ b/packages/beidou-cli/lib/commands/build.js
@@ -9,6 +9,7 @@ const {
   getArgvWithDefaultFramework = 'beidou',
   framework,
   cmdName,
+  webpack = 'beidou-webpack'
 } = require('../helper');
 
 module.exports = class BuildCMD extends Command {
@@ -31,9 +32,9 @@ module.exports = class BuildCMD extends Command {
 
   async run(context) {
     const buildPaths = [
-      path.join(context.cwd, 'node_modules/beidou-webpack/bin/build.js'),
-      path.join(__dirname, '../../../beidou-webpack/bin/build.js'),
-      () => require.resolve('beidou-webpack/bin/build'),
+      path.join(context.cwd, `node_modules/${webpack}/bin/build.js`),
+      path.join(__dirname, `../../../${webpack}/bin/build.js`),
+      () => require.resolve(`${webpack}/bin/build`),
     ];
     const buildBin = buildPaths.find(p =>
       fs.existsSync(typeof p === 'function' ? p() : p)


### PR DESCRIPTION
支持 自定义 webpack 扩展插件 、使用姿势如下：

若希望使用 beidou-webpack-done 替换 beidou 自身的 beidou-webpack ，则需要以下2个步骤
1、`beidou build --webpack=beidou-webpack-done` 
2、 在 plugin.js 中 
`exports.webpack = {
  enable: true,
  package: 'beidou-webpack-done',
  env: ['local', 'unittest'],
};`