### PR TITLE
feat: 支持外部指定 webpack

### DIFF
--- a/packages/beidou-cli/lib/commands/build.js
+++ b/packages/beidou-cli/lib/commands/build.js
@@ -30,10 +30,11 @@ module.exports = class BuildCMD extends Command {
   }
 
   async run(context) {
+    const wpconfig = context.argv.webpack || 'beidou-webpack'
     const buildPaths = [
-      path.join(context.cwd, 'node_modules/beidou-webpack/bin/build.js'),
-      path.join(__dirname, '../../../beidou-webpack/bin/build.js'),
-      () => require.resolve('beidou-webpack/bin/build'),
+      path.join(context.cwd, `node_modules/${wpconfig}/bin/build.js`),
+      path.join(__dirname, `../../../${wpconfig}/bin/build.js`),
+      () => require.resolve(`${wpconfig}/bin/build`),,
     ];
     const buildBin = buildPaths.find(p =>
       fs.existsSync(typeof p === 'function' ? p() : p)

--- a/packages/beidou-webpack/bin/build.js
+++ b/packages/beidou-webpack/bin/build.js
@@ -56,7 +56,7 @@ compiler.run((err, stats) => {
     process.exit(1);
   }
   if (stats) {
-    fs.writeFileSync(path.join(process.cwd(), '.stats'), stats);
+    fs.writeFileSync(path.join(process.cwd(), '.stats'), stats.toString());
     console.log(
       stats.toString({
         colors: true,

--- a/packages/beidou-webpack/lib/plugin/isomorphic.js
+++ b/packages/beidou-webpack/lib/plugin/isomorphic.js
@@ -69,7 +69,7 @@ IsomorphicPlugin.prototype.apply = function (compiler) {
   const cb = (stats) => {
     const json = stats.toJson();
 
-    debug('webpack compile json:\n', JSON.stringify(json, null, 2));
+    debug('webpack compile json:\n');
     const results = json.modules
       .map(module => this.parse(module))
       .filter(result => result);

--- a/packages/beidou-webpack/package.json
+++ b/packages/beidou-webpack/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "beidou-webpack",
-  "version": "2.2.1",
+  "name": "beidou-webpack-done",
+  "version": "1.0.0",
   "description": "beidou webpack middleware",
   "eggPlugin": {
     "name": "webpack"


### PR DESCRIPTION
支持 自定义 webpack 扩展插件 、使用姿势如下：

若希望使用 beidou-webpack-done 替换 beidou 自身的 beidou-webpack ，则需要以下2个步骤
1、beidou build --webpack=beidou-webpack-done
2、 在 plugin.js 中
exports.webpack = { enable: true, package: 'beidou-webpack-done', env: ['local', 'unittest'], };