### PR TITLE
feat: 支持 webpack 自定义build

### DIFF
--- a/packages/beidou-cli/lib/commands/build.js
+++ b/packages/beidou-cli/lib/commands/build.js
@@ -35,6 +35,10 @@ module.exports = class BuildCMD extends Command {
       path.join(__dirname, '../../../beidou-webpack/bin/build.js'),
       () => require.resolve('beidou-webpack/bin/build'),
     ];
+    const customBuildPath = context.argv.customBuildPath || '';
+    if(customBuildPath) {
+      buildPaths.unshift(path.join(context.cwd, customBuildPath));
+    }
     const buildBin = buildPaths.find(p =>
       fs.existsSync(typeof p === 'function' ? p() : p)
     );


### PR DESCRIPTION
支持 自定义 webpack 扩展插件 、使用姿势如下：

若希望使用 beidou-webpack-done 替换 beidou 自身的 beidou-webpack ，则需要以下2个步骤
1、beidou build --customBuildPath=node_modules/beidou-webpack-done/bin/build.js
2、在 plugin.js 中
exports.webpack = { enable: true, package: 'beidou-webpack-done', env: ['local', 'unittest'], };